### PR TITLE
Update BaseformTokenFilter.java

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/index/analysis/BaseformTokenFilter.java
+++ b/src/main/java/org/xbib/elasticsearch/index/analysis/BaseformTokenFilter.java
@@ -59,10 +59,11 @@ public class BaseformTokenFilter extends TokenFilter {
 
     protected void injectBaseform() throws CharacterCodingException {
         int start = offsetAtt.startOffset();
+        int end = offsetAtt.endOffset();
         CharSequence term = new String(termAtt.buffer(), 0, termAtt.length());
         CharSequence s = dictionary.lookup(term);
         if (s != null) {
-            tokens.add(new Token(s.toString(), start, start + s.length()));
+            tokens.add(new Token(s.toString(), start, end));
         }
     }
 


### PR DESCRIPTION
problem with highlighting fixed

For highlighting needs to hold original startOffset and endOffset values.
